### PR TITLE
fix(design): radius-card 14px + sidebar brand tracking

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -77,7 +77,7 @@
   --color-source-vscode: hsl(var(--source-vscode));
 
   /* Radius tokens */
-  --radius-card: 16px;
+  --radius-card: 14px;
   --radius-widget: 10px;
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -299,7 +299,9 @@ export function Sidebar() {
                     height={24}
                     className="shrink-0"
                   />
-                  <span className="text-lg font-bold tracking-tighter text-primary">Pika</span>
+                  <span className="text-lg font-bold tracking-tighter text-primary">
+                    Pika
+                  </span>
                   <Badge
                     variant="secondary"
                     className="px-1.5 py-0 text-micro font-normal text-muted-foreground"

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -299,7 +299,7 @@ export function Sidebar() {
                     height={24}
                     className="shrink-0"
                   />
-                  <span className="text-lg font-bold text-primary">Pika</span>
+                  <span className="text-lg font-bold tracking-tighter text-primary">Pika</span>
                   <Badge
                     variant="secondary"
                     className="px-1.5 py-0 text-micro font-normal text-muted-foreground"


### PR DESCRIPTION
## 变更

- `--radius-card` 从 16px 修正为 14px（Basalt B05-4 规范）
- Sidebar brand 文字添加 `tracking-tighter`（Basalt B02-2 规范）

Closes #13
