### PR TITLE
fix(design): standardize icon strokeWidth to 1.5

### DIFF
--- a/packages/web/src/app/dashboard/search/page.tsx
+++ b/packages/web/src/app/dashboard/search/page.tsx
@@ -119,7 +119,7 @@ export default function SearchPage() {
             className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
             fill="none"
             viewBox="0 0 24 24"
-            strokeWidth={2}
+            strokeWidth={1.5}
             stroke="currentColor"
             aria-hidden="true"
           >
@@ -188,7 +188,7 @@ export default function SearchPage() {
             className="size-12 mb-3 text-muted-foreground/30"
             fill="none"
             viewBox="0 0 24 24"
-            strokeWidth={1}
+            strokeWidth={1.5}
             stroke="currentColor"
             aria-hidden="true"
           >
@@ -209,7 +209,7 @@ export default function SearchPage() {
             className="size-12 mb-3 text-muted-foreground/30"
             fill="none"
             viewBox="0 0 24 24"
-            strokeWidth={1}
+            strokeWidth={1.5}
             stroke="currentColor"
             aria-hidden="true"
           >

--- a/packages/web/src/app/dashboard/sessions/[id]/page.tsx
+++ b/packages/web/src/app/dashboard/sessions/[id]/page.tsx
@@ -100,7 +100,7 @@ export default function SessionDetailPage() {
             className="size-4"
             fill="none"
             viewBox="0 0 24 24"
-            strokeWidth={2}
+            strokeWidth={1.5}
             stroke="currentColor"
             aria-hidden="true"
           >

--- a/packages/web/src/components/landing/landing-content.tsx
+++ b/packages/web/src/components/landing/landing-content.tsx
@@ -32,13 +32,13 @@ function InstallCommand() {
       {copied ? (
         <Check
           className="h-4 w-4 text-success shrink-0"
-          strokeWidth={2}
+          strokeWidth={1.5}
           aria-hidden="true"
         />
       ) : (
         <Copy
           className="h-4 w-4 text-muted-foreground group-hover:text-foreground shrink-0 transition-[color] duration-200"
-          strokeWidth={2}
+          strokeWidth={1.5}
           aria-hidden="true"
         />
       )}

--- a/packages/web/src/components/projects/project-activity-chart.tsx
+++ b/packages/web/src/components/projects/project-activity-chart.tsx
@@ -394,7 +394,7 @@ export function ProjectActivityChart({
               type="monotone"
               dataKey={primaryKey}
               stroke={primaryMetric.color}
-              strokeWidth={2}
+              strokeWidth={1.5}
               fill="url(#gradPrimary)"
             />
             {/* Secondary metric: Line */}
@@ -404,7 +404,7 @@ export function ProjectActivityChart({
                 type="monotone"
                 dataKey={secondaryMetric.key}
                 stroke={secondaryMetric.color}
-                strokeWidth={2}
+                strokeWidth={1.5}
                 dot={false}
                 strokeDasharray="4 2"
               />

--- a/packages/web/src/components/search/search-dialog.tsx
+++ b/packages/web/src/components/search/search-dialog.tsx
@@ -149,7 +149,7 @@ function SearchDialogContent({
             className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
             fill="none"
             viewBox="0 0 24 24"
-            strokeWidth={2}
+            strokeWidth={1.5}
             stroke="currentColor"
             aria-hidden="true"
           >
@@ -240,7 +240,7 @@ function SearchDialogContent({
               className="size-12 mb-3 text-muted-foreground/30"
               fill="none"
               viewBox="0 0 24 24"
-              strokeWidth={1}
+              strokeWidth={1.5}
               stroke="currentColor"
               aria-hidden="true"
             >
@@ -261,7 +261,7 @@ function SearchDialogContent({
               className="size-12 mb-3 text-muted-foreground/30"
               fill="none"
               viewBox="0 0 24 24"
-              strokeWidth={1}
+              strokeWidth={1.5}
               stroke="currentColor"
               aria-hidden="true"
             >

--- a/packages/web/src/components/ui/agent-icon.tsx
+++ b/packages/web/src/components/ui/agent-icon.tsx
@@ -49,7 +49,7 @@ function OpenCodeIcon({ className }: { className?: string }) {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={2}
+      strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
       className={cn("size-4", className)}
@@ -67,7 +67,7 @@ function CopilotIcon({ className }: { className?: string }) {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={2}
+      strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
       className={cn("size-4", className)}
@@ -106,7 +106,7 @@ export function AgentIcon({ source, className }: AgentIconProps) {
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
-        strokeWidth={2}
+        strokeWidth={1.5}
         strokeLinecap="round"
         strokeLinejoin="round"
         className={cn("size-4", className)}


### PR DESCRIPTION
## 变更

统一所有 Lucide icon 的 `strokeWidth` 为 `1.5`（Basalt B04-10 规范）：
- `strokeWidth={2}` → `1.5`（10 处）
- `strokeWidth={1}` → `1.5`（4 处）

涉及 6 个文件，共 14 处修改。

Closes #14
