### PR TITLE
fix(ui): align bg-card usage to B05 luminance spec

### DIFF
--- a/packages/web/src/app/dashboard/settings/tags/page.tsx
+++ b/packages/web/src/app/dashboard/settings/tags/page.tsx
@@ -257,7 +257,7 @@ export default function TagsSettingsPage() {
           {tags.map((tag) => (
             <div
               key={tag.id}
-              className="flex items-center gap-3 rounded-[var(--radius-card)] bg-card px-4 py-3"
+              className="flex items-center gap-3 rounded-[var(--radius-card)] bg-secondary px-4 py-3"
             >
               {editingId === tag.id ? (
                 /* Edit mode */

--- a/packages/web/src/components/dashboard/period-selector.tsx
+++ b/packages/web/src/components/dashboard/period-selector.tsx
@@ -50,7 +50,7 @@ export function PeriodSelector({ value, onChange }: PeriodSelectorProps) {
           className={cn(
             "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
             value === opt.value
-              ? "bg-card text-foreground shadow-sm"
+              ? "bg-secondary text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground",
           )}
         >

--- a/packages/web/src/components/dashboard/stat-card.tsx
+++ b/packages/web/src/components/dashboard/stat-card.tsx
@@ -97,7 +97,7 @@ export function StatCard({
           )}
         </div>
         {Icon && (
-          <div className={cn("rounded-md bg-card p-2", iconColor)}>
+          <div className={cn("rounded-md bg-background p-2", iconColor)}>
             <Icon
               className={cn(isPrimary ? "h-6 w-6" : "h-5 w-5")}
               strokeWidth={1.5}

--- a/packages/web/src/components/projects/project-card.tsx
+++ b/packages/web/src/components/projects/project-card.tsx
@@ -63,7 +63,7 @@ export function ProjectCard({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex items-start gap-3 rounded-[var(--radius-card)] bg-card p-4 text-left transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "flex items-start gap-3 rounded-[var(--radius-card)] bg-secondary p-4 text-left transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         selected && "bg-accent/30 ring-2 ring-primary",
       )}
     >

--- a/packages/web/src/components/search/search-result-card.tsx
+++ b/packages/web/src/components/search/search-result-card.tsx
@@ -106,7 +106,7 @@ export function SearchResultCard({
   "data-result-index": dataResultIndex,
 }: SearchResultCardProps) {
   const cardClassName = cn(
-    "flex flex-col gap-2 rounded-[var(--radius-card)] bg-card p-4 transition-colors hover:bg-accent/50 text-left w-full",
+    "flex flex-col gap-2 rounded-[var(--radius-card)] bg-secondary p-4 transition-colors hover:bg-accent/50 text-left w-full",
     selected && "ring-2 ring-primary bg-accent/30",
     className,
   );

--- a/packages/web/src/components/sessions/session-card.tsx
+++ b/packages/web/src/components/sessions/session-card.tsx
@@ -80,7 +80,7 @@ export function SessionCard({ session, className }: SessionCardProps) {
     <Link
       href={`/dashboard/sessions/${session.id}`}
       className={cn(
-        "flex flex-col gap-2 rounded-[var(--radius-card)] bg-card p-4 transition-colors hover:bg-accent/50",
+        "flex flex-col gap-2 rounded-[var(--radius-card)] bg-secondary p-4 transition-colors hover:bg-accent/50",
         className,
       )}
       data-testid="session-card"


### PR DESCRIPTION
Closes #17\n\nReplace misused bg-card (L1) with bg-secondary (L2) for content cards inside the floating island, per Basalt B05 spec.