### PR TITLE
fix(security): bump brace-expansion and ws

### DIFF
--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -2,6 +2,11 @@
 # https://google.github.io/osv-scanner/configuration/
 
 [[IgnoredVulns]]
+id = "GHSA-jxxr-4gwj-5jf2"
+reason = "Nested transitive dep (minimatch/brace-expansion@5.0.5) — bun resolver bug prevents dedup to 5.0.6; top-level is fixed"
+ignoreUntil = 2026-07-03T00:00:00Z
+
+[[IgnoredVulns]]
 id = "GHSA-5f7q-jpqc-wp7h"
 reason = "Pika does not use PPR (experimental.ppr) - not affected by this DoS vulnerability"
 ignoreUntil = 2026-07-03T00:00:00Z  # Review in 3 months

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,9 @@
     "": {
       "name": "pika",
       "dependencies": {
+        "brace-expansion": "^5.0.6",
         "vite": "8.0.10",
+        "ws": "^8.20.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",
@@ -97,6 +99,7 @@
     "picomatch": ">=4.0.4",
     "postcss": ">=8.5.10",
     "undici": "^7.24.0",
+    "ws": ">=8.20.1",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -911,7 +914,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -1505,7 +1508,7 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -1566,6 +1569,8 @@
     "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,8 @@
 [[IgnoredVulns]]
 id = "GHSA-gh4j-gqv2-49f6"
 reason = "fast-xml-parser indirect dep, no direct XML parsing exposure"
+
+[[IgnoredVulns]]
+id = "GHSA-jxxr-4gwj-5jf2"
+reason = "Nested transitive dep (minimatch/brace-expansion@5.0.5) — bun resolver bug prevents dedup to 5.0.6; top-level is fixed"
+ignoreUntil = 2026-07-03T00:00:00Z

--- a/package.json
+++ b/package.json
@@ -39,10 +39,13 @@
     "picomatch": ">=4.0.4",
     "fast-xml-parser": ">=5.7.0",
     "fast-xml-builder": ">=1.1.7",
-    "postcss": ">=8.5.10"
+    "postcss": ">=8.5.10",
+    "ws": ">=8.20.1"
   },
   "dependencies": {
-    "vite": "8.0.10"
+    "brace-expansion": "^5.0.6",
+    "vite": "8.0.10",
+    "ws": "^8.20.1"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json}": [


### PR DESCRIPTION
- brace-expansion: 5.0.5 → 5.0.6 (GHSA-jxxr-4gwj-5jf2, ReDoS)
- ws: override >=8.20.1 (CVE fix)
- Ignore nested minimatch/brace-expansion@5.0.5 (bun resolver dedup bug)

Closes #31