### PR TITLE
ci: fix wrangler-action deploy with bun packageManager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,12 @@ jobs:
         run: bun run build
 
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/web-worker
+          packageManager: bun
           command: deploy --env=""
 
       - name: Verify deployment


### PR DESCRIPTION
wrangler-action 内部默认用 npm 安装 wrangler，但项目使用 bun。npm 不支持 workspace: 协议和某些 overrides 写法，导致 Deploy Worker step 失败。\n\n修复：添加 packageManager: bun 让 wrangler-action 使用 bun 安装。