### PR TITLE
deps(web-worker): bump @cloudflare/workers-types to ^4.20260613.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260612.1",
+        "@cloudflare/workers-types": "4.20260613.1",
         "typescript": "^6.0.3",
         "vitest": "^3.2.6",
         "wrangler": "^4.99.0",

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -16,7 +16,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260612.1",
+    "@cloudflare/workers-types": "^4.20260613.1",
     "typescript": "^6.0.3",
     "vitest": "^3.2.6",
     "wrangler": "^4.99.0"


### PR DESCRIPTION
## Summary

- Bump `@cloudflare/workers-types` from `^4.20260612.1` to `^4.20260613.1` in `packages/web-worker` (devDependencies, minor).

## Verification

- `bun run lint` (root + web + web-worker tsc) — pass
- `vitest run` in `packages/web-worker` — 298/298 pass
- pre-push: Build + L1 + G1 + G2 — pass

Closes nocoo/pika#87