### PR TITLE
security(web-worker): fail-closed CF Access middleware (#108)

### DIFF
--- a/docs/00-architecture.md
+++ b/docs/00-architecture.md
@@ -97,7 +97,7 @@ src/
 accessAuth → apiKeyAuth → resolveUser → handler
 ```
 
-- `accessAuth`：验签 CF Access JWT；失败不 401，落到下一个。`/api/live` 公开。本地 dev 跳过。
+- `accessAuth`：验签 CF Access JWT — **fail-closed**：env 缺失 → 500，JWT 缺失 → 401，验签失败 → 403。`/api/live` 公开。本地 dev 跳过（保留 `DEV_USER_EMAIL` 注入）。例外：`/api/ingest/*` 带 `Authorization: Bearer ...` 时直接放行给 `apiKeyAuth`，因为 CF Access 在 `/api/ingest/*` 配的是 path-level **bypass policy**，CLI 请求不会带 JWT；Bearer 短路严格限定在 `/api/ingest/*`，防止泄露的 `pk_*` 在浏览器路径上替代 CF Access。
 - `apiKeyAuth`：识别 `Authorization: Bearer pk_*`，查 `api_tokens` 表，set `userId`。
 - `resolveUser`：如果 `userId` 已被 apiKeyAuth set 过则跳过；否则用 `accessEmail` 查 `users` 表 set `userId`。
 - 终端 401：handler 自己用 `requireAuth(c)` 判断。

--- a/packages/web-worker/src/middleware/access-auth.test.ts
+++ b/packages/web-worker/src/middleware/access-auth.test.ts
@@ -25,6 +25,12 @@ function makeApp(env: Partial<AppEnv["Bindings"]> = {}) {
       email: c.get("accessEmail") ?? null,
     }),
   );
+  app.post("/api/ingest/sessions", (c) =>
+    c.json({
+      reached: true,
+      authed: c.get("accessAuthenticated") ?? false,
+    }),
+  );
   return {
     fetch: (req: Request) =>
       app.fetch(req, env as unknown as Record<string, unknown>),
@@ -100,7 +106,7 @@ describe("accessAuth", () => {
     expect(body.authed).toBe(false);
   });
 
-  it("non-local CLI request with Bearer defers to apiKeyAuth (no 401 here)", async () => {
+  it("non-local CLI request to /api/ingest/* with Bearer defers to apiKeyAuth", async () => {
     // CLI hits /api/ingest/* through the CF Access path-level bypass policy
     // (docs/00-architecture.md §4). The bypass strips Cf-Access-Jwt-Assertion
     // but the request still carries a Bearer pk_* — accessAuth must let it
@@ -111,15 +117,60 @@ describe("accessAuth", () => {
     });
     const res = await app.fetch(
       new Request("https://pika.hexly.ai/api/ingest/sessions", {
+        method: "POST",
         headers: { Authorization: "Bearer pk_test" },
       }),
     );
-    // Falls through to the next middleware; our test app has no handler for
-    // /api/ingest, but the important thing is accessAuth did not 401/500.
-    expect(res.status).not.toBe(401);
-    expect(res.status).not.toBe(403);
-    expect(res.status).not.toBe(500);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { reached: boolean; authed: boolean };
+    expect(body.reached).toBe(true);
+    expect(body.authed).toBe(false);
     expect(verifyMock).not.toHaveBeenCalled();
+  });
+
+  it("non-local /api/ingest/* without Bearer still hits CF Access (no implicit bypass)", async () => {
+    // The Bearer escape hatch requires both /api/ingest/* AND a Bearer header.
+    // A request to /api/ingest/* missing the Bearer must still be subject to
+    // CF Access checks — env-missing returns 500, JWT-missing returns 401.
+    const app = makeApp({
+      CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
+      CF_ACCESS_AUD: "aud",
+    });
+    const res = await app.fetch(
+      new Request("https://pika.hexly.ai/api/ingest/sessions", {
+        method: "POST",
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Missing Access JWT" });
+    expect(verifyMock).not.toHaveBeenCalled();
+  });
+
+  it("non-local browser path with Bearer but no JWT → 401 (Bearer escape is ingest-only)", async () => {
+    // A leaked pk_* must NOT bypass CF Access on /api/me, /api/auth/tokens,
+    // /api/sessions, etc. — the Bearer escape hatch is scoped to /api/ingest/*.
+    const app = makeApp({
+      CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
+      CF_ACCESS_AUD: "aud",
+    });
+    const res = await app.fetch(
+      new Request("https://pika.hexly.ai/api/me", {
+        headers: { Authorization: "Bearer pk_test" },
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Missing Access JWT" });
+    expect(verifyMock).not.toHaveBeenCalled();
+  });
+
+  it("non-local browser path with Bearer and env missing → 500 (fail-closed)", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      new Request("https://pika.hexly.ai/api/me", {
+        headers: { Authorization: "Bearer pk_test" },
+      }),
+    );
+    expect(res.status).toBe(500);
   });
 
   it("non-local without CF Access env vars → 500 (fail-closed)", async () => {

--- a/packages/web-worker/src/middleware/access-auth.test.ts
+++ b/packages/web-worker/src/middleware/access-auth.test.ts
@@ -100,21 +100,46 @@ describe("accessAuth", () => {
     expect(body.authed).toBe(false);
   });
 
-  it("non-local without CF Access env vars passes through unauthenticated", async () => {
-    const app = makeApp();
-    const res = await app.fetch(new Request("https://pika.hexly.ai/api/me"));
-    const body = (await res.json()) as { authed: boolean };
-    expect(body.authed).toBe(false);
+  it("non-local CLI request with Bearer defers to apiKeyAuth (no 401 here)", async () => {
+    // CLI hits /api/ingest/* through the CF Access path-level bypass policy
+    // (docs/00-architecture.md §4). The bypass strips Cf-Access-Jwt-Assertion
+    // but the request still carries a Bearer pk_* — accessAuth must let it
+    // through unauthenticated so apiKeyAuth can verify the token.
+    const app = makeApp({
+      CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
+      CF_ACCESS_AUD: "aud",
+    });
+    const res = await app.fetch(
+      new Request("https://pika.hexly.ai/api/ingest/sessions", {
+        headers: { Authorization: "Bearer pk_test" },
+      }),
+    );
+    // Falls through to the next middleware; our test app has no handler for
+    // /api/ingest, but the important thing is accessAuth did not 401/500.
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(500);
+    expect(verifyMock).not.toHaveBeenCalled();
   });
 
-  it("non-local without JWT header passes through", async () => {
+  it("non-local without CF Access env vars → 500 (fail-closed)", async () => {
+    const app = makeApp();
+    const res = await app.fetch(new Request("https://pika.hexly.ai/api/me"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error:
+        "Access authentication not configured. Set CF_ACCESS_TEAM_DOMAIN and CF_ACCESS_AUD.",
+    });
+  });
+
+  it("non-local without JWT header → 401 (fail-closed)", async () => {
     const app = makeApp({
       CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
       CF_ACCESS_AUD: "aud",
     });
     const res = await app.fetch(new Request("https://pika.hexly.ai/api/me"));
-    const body = (await res.json()) as { authed: boolean };
-    expect(body.authed).toBe(false);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Missing Access JWT" });
     expect(verifyMock).not.toHaveBeenCalled();
   });
 
@@ -158,7 +183,7 @@ describe("accessAuth", () => {
     expect(createJWKSMock).toHaveBeenCalledTimes(1);
   });
 
-  it("invalid JWT falls through (no throw, no auth set)", async () => {
+  it("invalid JWT → 403 (fail-closed)", async () => {
     verifyMock.mockRejectedValueOnce(new Error("bad sig"));
     const app = makeApp({
       CF_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
@@ -169,8 +194,8 @@ describe("accessAuth", () => {
         headers: { "Cf-Access-Jwt-Assertion": "bad.jwt" },
       }),
     );
-    const body = (await res.json()) as { authed: boolean };
-    expect(body.authed).toBe(false);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Invalid Access JWT" });
   });
 
   it("payload without string email leaves accessEmail unset", async () => {

--- a/packages/web-worker/src/middleware/access-auth.ts
+++ b/packages/web-worker/src/middleware/access-auth.ts
@@ -4,6 +4,7 @@ import type { AppEnv } from "../lib/env";
 import { isLocalhost } from "./is-localhost";
 
 const PUBLIC_PATHS = new Set<string>(["/api/live"]);
+const INGEST_BEARER_PATH_PREFIX = "/api/ingest/";
 
 let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
 let jwksCacheTeamDomain: string | null = null;
@@ -37,12 +38,16 @@ export function __resetAccessAuthCacheForTests() {
  * - On localhost without a Bearer header we set `accessAuthenticated` so
  *   the dev-email branch in `resolveUser` can run; with a Bearer we let
  *   `apiKeyAuth` handle it (so `accessEmail` reflects the token owner).
- * - On a real edge request carrying a Bearer token, we defer to
- *   `apiKeyAuth`. CLI traffic hits `/api/ingest/*` through CF Access's
- *   path-level bypass policy and therefore never carries a Cf-Access-Jwt-
- *   Assertion header — rejecting it here would break the documented CLI
- *   flow (docs/00-architecture.md §4).
- * - For browser traffic (no Bearer): env misconfigured → 500, missing
+ * - On a real edge request to `/api/ingest/*` carrying a Bearer token,
+ *   we defer to `apiKeyAuth`. CLI traffic hits `/api/ingest/*` through
+ *   CF Access's path-level bypass policy and therefore never carries a
+ *   Cf-Access-Jwt-Assertion header — rejecting it here would break the
+ *   documented CLI flow (docs/00-architecture.md §4). The Bearer escape
+ *   hatch is scoped to `/api/ingest/*` so a leaked `pk_*` cannot be used
+ *   to bypass CF Access on browser-only paths (`/api/me`,
+ *   `/api/auth/tokens`, `/api/sessions`, …) when a request reaches the
+ *   Worker directly (workers.dev / preview / custom domain misroute).
+ * - For all other browser traffic: env misconfigured → 500, missing
  *   JWT → 401, invalid JWT → 403. No silent pass-through.
  */
 export async function accessAuth(c: Context<AppEnv>, next: Next) {
@@ -65,9 +70,15 @@ export async function accessAuth(c: Context<AppEnv>, next: Next) {
   }
 
   // CLI path: CF Access bypass on `/api/ingest/*` strips the JWT but
-  // forwards the Bearer header. Let `apiKeyAuth` own validation.
-  const hasBearer = (c.req.header("Authorization") ?? "").startsWith("Bearer ");
-  if (hasBearer) return next();
+  // forwards the Bearer header. Let `apiKeyAuth` own validation. Scoped
+  // to `/api/ingest/*` so `pk_*` cannot stand in for CF Access on
+  // browser-only paths if a request reaches the Worker directly.
+  if (c.req.path.startsWith(INGEST_BEARER_PATH_PREFIX)) {
+    const hasBearer = (c.req.header("Authorization") ?? "").startsWith(
+      "Bearer ",
+    );
+    if (hasBearer) return next();
+  }
 
   const teamDomain = c.env.CF_ACCESS_TEAM_DOMAIN;
   const aud = c.env.CF_ACCESS_AUD;

--- a/packages/web-worker/src/middleware/access-auth.ts
+++ b/packages/web-worker/src/middleware/access-auth.ts
@@ -27,16 +27,23 @@ export function __resetAccessAuthCacheForTests() {
 }
 
 /**
- * Cloudflare Access JWT verification.
+ * Cloudflare Access JWT verification — fail-CLOSED.
  *
- * Verified requests get `c.set("accessAuthenticated", true)` and
+ * Verified browser requests get `c.set("accessAuthenticated", true)` and
  * `c.set("accessEmail", payload.email)`.
  *
+ * Routing:
  * - `/api/live` is always public.
  * - On localhost without a Bearer header we set `accessAuthenticated` so
  *   the dev-email branch in `resolveUser` can run; with a Bearer we let
  *   `apiKeyAuth` handle it (so `accessEmail` reflects the token owner).
- * - JWT failure does NOT 401 here — fall through to `apiKeyAuth`.
+ * - On a real edge request carrying a Bearer token, we defer to
+ *   `apiKeyAuth`. CLI traffic hits `/api/ingest/*` through CF Access's
+ *   path-level bypass policy and therefore never carries a Cf-Access-Jwt-
+ *   Assertion header — rejecting it here would break the documented CLI
+ *   flow (docs/00-architecture.md §4).
+ * - For browser traffic (no Bearer): env misconfigured → 500, missing
+ *   JWT → 401, invalid JWT → 403. No silent pass-through.
  */
 export async function accessAuth(c: Context<AppEnv>, next: Next) {
   if (PUBLIC_PATHS.has(c.req.path)) return next();
@@ -57,12 +64,25 @@ export async function accessAuth(c: Context<AppEnv>, next: Next) {
     return next();
   }
 
+  // CLI path: CF Access bypass on `/api/ingest/*` strips the JWT but
+  // forwards the Bearer header. Let `apiKeyAuth` own validation.
+  const hasBearer = (c.req.header("Authorization") ?? "").startsWith("Bearer ");
+  if (hasBearer) return next();
+
   const teamDomain = c.env.CF_ACCESS_TEAM_DOMAIN;
   const aud = c.env.CF_ACCESS_AUD;
-  if (!(teamDomain && aud)) return next();
+  if (!(teamDomain && aud)) {
+    return c.json(
+      {
+        error:
+          "Access authentication not configured. Set CF_ACCESS_TEAM_DOMAIN and CF_ACCESS_AUD.",
+      },
+      500,
+    );
+  }
 
   const jwt = c.req.header("Cf-Access-Jwt-Assertion");
-  if (!jwt) return next();
+  if (!jwt) return c.json({ error: "Missing Access JWT" }, 401);
 
   try {
     const jwks = getJWKS(teamDomain);
@@ -74,7 +94,8 @@ export async function accessAuth(c: Context<AppEnv>, next: Next) {
     const email = (payload as JWTPayload & { email?: unknown }).email;
     if (typeof email === "string") c.set("accessEmail", email);
   } catch {
-    // fall through; api-key-auth or terminal 401 will handle it
+    return c.json({ error: "Invalid Access JWT" }, 403);
   }
+
   return next();
 }


### PR DESCRIPTION
## Summary

修复 `packages/web-worker/src/middleware/access-auth.ts` 在 CF Access 路径上的三处 fail-open，把中间件改为 **fail-closed**：

- env 缺失（`CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` 任一为空） → **500**
- `Cf-Access-Jwt-Assertion` header 缺失 → **401**
- `jwtVerify` 抛错（签名/issuer/audience 任一不匹配） → **403**

参考标杆 `nocoo/bat:packages/worker/src/middleware/access-auth.ts`，但 pika 比 bat 多一条 CLI 通道：`/api/ingest/*` 在 CF Access 上配的是 path-level **bypass policy**，bypass 会剥掉 JWT 但保留 `Authorization: Bearer pk_*`。因此保留了一条严格收窄的 Bearer 短路：仅当 `c.req.path.startsWith("/api/ingest/")` **且** 带 `Bearer` header 时跳过 JWT 校验，让下游 `apiKeyAuth` 负责 token 验证。

非 `/api/ingest/*` 路径的 Bearer 头在 `accessAuth` 这一层会被忽略，防止泄露的 `pk_*` 在浏览器路径上替代 CF Access。

`docs/00-architecture.md` §3 同步更新（fail-closed 语义 + `/api/ingest/*` 例外边界）。

Closes nocoo/pika#108

## Test plan

- [x] `bunx vitest run` — 63 文件 / 1444 用例全过
- [x] `bunx vitest run --coverage` — Branches 90.1% 过阈值
- [x] `bun run lint`（3 个 tsconfig） — 零 error
- [x] `bun run lint:biome` — 零 error
- [x] `bun run build` — 成功
- [x] `access-auth.test.ts` 新增 4 个回归用例：
  - `/api/ingest/* + Bearer` → 200，落到下游 handler
  - `/api/ingest/*` 无 Bearer + 无 JWT → **401**（确认不是隐式 bypass）
  - `/api/me + Bearer + 无 JWT` → **401**（确认 `pk_*` 不能在浏览器路径替代 CF Access）
  - `/api/me + Bearer + env 缺失` → **500**（确认带 Bearer 也仍是 fail-closed）
- [x] 已通过 Reviewer-03 review
- [ ] CI 通过
- [ ] Merge 后关闭 nocoo/pika#108
