### PR TITLE
chore(deps): bump @cloudflare/workers-types 4.20260620.1 → 4.20260621.1 in web-worker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260620.1",
+        "@cloudflare/workers-types": "4.20260621.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
         "wrangler": "^4.103.0",
@@ -217,7 +217,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260617.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260620.1", "", {}, "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260621.1", "", {}, "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -16,7 +16,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260620.1",
+    "@cloudflare/workers-types": "4.20260621.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "wrangler": "^4.103.0"


### PR DESCRIPTION
## Summary

- Bump `@cloudflare/workers-types` from `4.20260620.1` to `4.20260621.1` in `packages/web-worker` (devDependency)
- Preserve the existing pinned-version style used for this dep
- Sync `bun.lock`

Closes nocoo/pika#127

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run lint` (3 tsconfigs)
- [x] `bun run lint:biome` — 259 files clean
- [x] `vitest run` — 63 files / 1445 tests pass, coverage 97.15% statements
- [x] `bun run lint:deps` (osv-scanner) — no issues
- [x] `bun run build` — succeeds (pre-existing large-chunk warning unrelated to this bump)
- [x] pre-commit + pre-push hooks green