### PR TITLE
chore(deps): bump @cloudflare/workers-types 4.20260625.1 → 4.20260626.1 in web-worker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260625.1",
+        "@cloudflare/workers-types": "4.20260626.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
         "wrangler": "^4.105.0",
@@ -216,7 +216,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260625.1", "", { "os": "win32", "cpu": "x64" }, "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260625.1", "", {}, "sha512-asH0RhPHiNu/IUSssyiOJYAcGqysy0DJpO9fihC6KATaayD9CE1E9bgNQozTLUraxrCT2qkM4CBOIcV0M5NPJw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260626.1", "", {}, "sha512-fBnpQyFRS3Ce1l2IUd3k+aUxgy/7VMlVXF4F672/eSrpXFeezCy3Ha6Z2uTyGgqu9sGvQPOj8nqKBv2yeI+ciw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -16,7 +16,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260625.1",
+    "@cloudflare/workers-types": "4.20260626.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "wrangler": "^4.105.0"


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` from `4.20260625.1` to `4.20260626.1` in `packages/web-worker` (devDependencies).

## Validation

- `bun run typecheck` ✅
- `bun run test` ✅ (64 files / 1445 tests)
- `bun run lint:all` via pre-commit / pre-push ✅

## Related

Closes nocoo/pika#150
