### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
## Summary
- Add root `.npmrc` pinning the official npm registry, enforcing `save-exact` / `package-lock` / `engine-strict`, and enabling `audit` (level=high) with `fund=false`.
- Config-only change; no install run, no touch to `package.json`, `bun.lock`, `bunfig.toml`, CI, or hooks.

## Test plan
- [x] `git diff --name-status origin/main..HEAD` → `A .npmrc` only
- [x] `.npmrc` contents match the issue spec verbatim (21 lines incl. blanks)

Refs: STU-1527